### PR TITLE
Fix docker compose build

### DIFF
--- a/docker/Dockerfile-jmc
+++ b/docker/Dockerfile-jmc
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-stretch AS builder
+FROM openjdk:11-jdk-stretch AS builder
 
 RUN apt-get update && apt-get install -y maven
 


### PR DESCRIPTION
The container for docker compose build needs to be version 11 since some of the dependencies were built for version 11.
Had a build failure due to this issue.